### PR TITLE
Added data_type entries

### DIFF
--- a/source/_components/sensor.rfxtrx.markdown
+++ b/source/_components/sensor.rfxtrx.markdown
@@ -56,10 +56,14 @@ sensor:
 ```
 Only these data_type are valid :
 - *Temperature*
+- *Chill*
 - *Humidity*
 - *Barometer*
 - *Wind direction*
+- *Wind gust*
+- *Wind average speed*
 - *Rain rate*
+- *Rain total*
 - *Energy usage*
 - *Total usage*
 - *Sound*


### PR DESCRIPTION
Added "Rain total", "Wind average speed", "Wind gust", and "Chill" (wind-chill) data types for use with TFA weather sensors.

See corresponding edit to rfxtrx.py.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

